### PR TITLE
update feed response with adding profile pic and content of the post

### DIFF
--- a/InstagramProject.Core/Contracts/Home/FeedResponse.cs
+++ b/InstagramProject.Core/Contracts/Home/FeedResponse.cs
@@ -11,6 +11,8 @@ namespace InstagramProject.Core.Contracts.Home
 		int PostId,
 		string userId,
 		string userName,
+		string ProfilePic,
+		string Content,
 		DateTime Time,
 		IEnumerable<string> media,
 		int Likes,

--- a/InstagramProject.Service/Services/Home/HomeService.cs
+++ b/InstagramProject.Service/Services/Home/HomeService.cs
@@ -39,7 +39,9 @@ namespace InstagramProject.Service.Services.Home
 				.Select(p => new FeedResponse(
 					p.Id,
 					p.UserId,
-					p.User.UserName ?? string.Empty,
+					p.User.UserName,
+					p.User.ProfilePic,
+					p.Content,
 					p.Time,
 					string.IsNullOrEmpty(p.PostMedia)
 						? Enumerable.Empty<string>()
@@ -64,7 +66,7 @@ namespace InstagramProject.Service.Services.Home
 					u.Id,
 					u.UserName!,
 					u.FullName,
-					u.ProfilePic ?? "https://res.cloudinary.com/dbpstijmp/image/upload/v1751892675/awgq5wbmds1147xvxnld.png"
+					u.ProfilePic
 				))
 				.AsNoTracking()
 				.ToListAsync(cancellationToken);
@@ -98,7 +100,7 @@ namespace InstagramProject.Service.Services.Home
 			var suggestions = suggestedUsers
 				.Join(userDetails, su => su.UserId, ud => ud.Id, (su, ud) => new SuggestionsFollowerResponse(
 					ud.UserName!,
-					ud.ProfilePic ?? "https://res.cloudinary.com/dbpstijmp/image/upload/v1751892675/awgq5wbmds1147xvxnld.png",
+					ud.ProfilePic,
 					su.MutualFriendsCount
 				)).ToList();
 


### PR DESCRIPTION
This pull request introduces enhancements to the `FeedResponse` model and updates several service methods in the `HomeService` class to improve data handling and remove default placeholder URLs for profile pictures. The most important changes include adding new fields to the `FeedResponse` model and ensuring profile picture URLs are handled consistently across different methods.

### Enhancements to `FeedResponse` model:
* Added `ProfilePic` and `Content` fields to the `FeedResponse` record to include profile picture URLs and post content in the feed response. (`InstagramProject.Core/Contracts/Home/FeedResponse.cs`, [InstagramProject.Core/Contracts/Home/FeedResponse.csR14-R15](diffhunk://#diff-0ea11c3eb8f6d2d023b85841fdc7bf8bc6ddd7afdf0ba4c829326c95981427e1R14-R15))

### Updates to `HomeService` methods:
* Updated the `UserFeedAsync` method to populate the new `ProfilePic` and `Content` fields for each feed item. (`InstagramProject.Service/Services/Home/HomeService.cs`, [InstagramProject.Service/Services/Home/HomeService.csL42-R44](diffhunk://#diff-b78ce84d1be7f1b230d84647017561fe4a3fbc768d8b791f45780e0948934e64L42-R44))
* Modified the `SearchForUserAsync` method to directly use the `ProfilePic` field without falling back to a default placeholder URL. (`InstagramProject.Service/Services/Home/HomeService.cs`, [InstagramProject.Service/Services/Home/HomeService.csL67-R69](diffhunk://#diff-b78ce84d1be7f1b230d84647017561fe4a3fbc768d8b791f45780e0948934e64L67-R69))
* Adjusted the `SuggestionsFollowerResponse` generation in the `SuggestionsFollowerAsync` method to remove the default placeholder URL for profile pictures and use the actual `ProfilePic` value. (`InstagramProject.Service/Services/Home/HomeService.cs`, [InstagramProject.Service/Services/Home/HomeService.csL101-R103](diffhunk://#diff-b78ce84d1be7f1b230d84647017561fe4a3fbc768d8b791f45780e0948934e64L101-R103))