### PR TITLE
Add react Service to create or remove react for Post or Comment

### DIFF
--- a/InstagramProject.Api/Controllers/ReactionController.cs
+++ b/InstagramProject.Api/Controllers/ReactionController.cs
@@ -1,0 +1,28 @@
+﻿using InstagramProject.Core.Contracts.Post;
+using InstagramProject.Core.Contracts.Reaction;
+using InstagramProject.Core.Extensions;
+using InstagramProject.Core.Service_contract;
+using InstagramProject.Core.ServiceContract;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using InstagramProject.Core.Abstractions;
+
+namespace InstagramProject.Api.Controllers
+{
+	[Route("api/[controller]")]
+	[ApiController]
+	public class ReactionController : ControllerBase
+	{
+		private readonly IReactionService _reactionService;
+		public ReactionController(IReactionService reactionService)
+		{
+			_reactionService = reactionService;
+		}
+		[HttpPost("")]
+		public async Task<IActionResult> CreateReact([FromBody] CreateReactionRequest request, CancellationToken cancellationToken)
+		{
+			var response = await _reactionService.CreateReactionAsync(User.GetUserId()!, request, cancellationToken);
+			return response.IsSuccess ? Ok(response.Value) : response.ToProblem();
+		}
+	}
+}

--- a/InstagramProject.Core/Contracts/Home/FeedResponse.cs
+++ b/InstagramProject.Core/Contracts/Home/FeedResponse.cs
@@ -11,6 +11,8 @@ namespace InstagramProject.Core.Contracts.Home
 		int PostId,
 		string userId,
 		string userName,
+		string ProfilePic,
+		string Content,
 		DateTime Time,
 		IEnumerable<string> media,
 		int Likes,

--- a/InstagramProject.Core/Contracts/Reaction/CreateReactionRequest.cs
+++ b/InstagramProject.Core/Contracts/Reaction/CreateReactionRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstagramProject.Core.Contracts.Reaction
+{
+	public record CreateReactionRequest
+	(
+		int PostId,
+		int? CommentId
+	);
+}

--- a/InstagramProject.Core/Contracts/Reaction/CreateReactionResponse.cs
+++ b/InstagramProject.Core/Contracts/Reaction/CreateReactionResponse.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstagramProject.Core.Contracts.Reaction
+{
+	public record CreateReactionResponse
+	(
+		int ReactionId,
+		string UserId,
+		string UserName,
+		int PostId,
+		int? CommentId,
+		DateTime Time
+	);
+}

--- a/InstagramProject.Core/Errors/Reaction/ReactionErrors.cs
+++ b/InstagramProject.Core/Errors/Reaction/ReactionErrors.cs
@@ -1,0 +1,13 @@
+﻿using InstagramProject.Core.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace InstagramProject.Core.Errors.Reaction
+{
+	public static class ReactionErrors
+	{
+		public static readonly Error UserNotFound = new("Reaction.UserNotFound", "User not found.", StatusCodes.Status404NotFound);
+		public static readonly Error PostNotFound = new("Reaction.PostNotFound", "Post not found.", StatusCodes.Status404NotFound);
+		public static readonly Error CommentNotFound = new("Reaction.CommentNotFound", "Comment not found.", StatusCodes.Status404NotFound);
+		public static readonly Error CommentNotInPost = new("Reaction.CommentNotInPost", "The comment does not belong to the specified post.", StatusCodes.Status400BadRequest);
+	}
+}

--- a/InstagramProject.Core/ServiceContract/IReactionService.cs
+++ b/InstagramProject.Core/ServiceContract/IReactionService.cs
@@ -1,0 +1,15 @@
+﻿using InstagramProject.Core.Abstractions;
+using InstagramProject.Core.Contracts.Reaction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstagramProject.Core.ServiceContract
+{
+	public interface IReactionService
+	{
+		Task<Result<CreateReactionResponse>> CreateReactionAsync(string userId, CreateReactionRequest request, CancellationToken cancellationToken = default);
+	}
+}

--- a/InstagramProject.Service/DependencyInjection.cs
+++ b/InstagramProject.Service/DependencyInjection.cs
@@ -3,6 +3,7 @@ using InstagramProject.Core.Helpers;
 using InstagramProject.Core.Service_contract;
 using InstagramProject.Core.ServiceContract;
 using InstagramProject.Service.Comment;
+using InstagramProject.Service.Reaction;
 using InstagramProject.Service.Services.Authentication;
 using InstagramProject.Service.Services.EmailService;
 using InstagramProject.Service.Services.Files;
@@ -31,6 +32,7 @@ namespace InstagramProject.Service
 			services.AddScoped<IPostService, PostService>();
 			services.AddScoped<IProfileService, ProfileService>();
 			services.AddScoped<ICommentService, CommentService>();
+			services.AddScoped<IReactionService, ReactionService>();
 			services.Configure<CloudinarySettings>(configuration.GetSection(CloudinarySettings.SectionName));
 			
 			services.AddBackgroundJobsConfig(configuration);

--- a/InstagramProject.Service/Reaction/ReactionService.cs
+++ b/InstagramProject.Service/Reaction/ReactionService.cs
@@ -1,0 +1,72 @@
+﻿using InstagramProject.Core.Abstractions;
+using InstagramProject.Core.Contracts.Common;
+using InstagramProject.Core.Contracts.Home;
+using InstagramProject.Core.Contracts.Reaction;
+using InstagramProject.Core.Entities.Auth;
+using InstagramProject.Core.Errors.Reaction;
+using InstagramProject.Core.ServiceContract;
+using InstagramProject.Repository.Data.Contexts;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace InstagramProject.Service.Reaction
+{
+	public class ReactionService : IReactionService
+	{
+		private readonly ApplicationDbContext _context;
+		private readonly UserManager<ApplicationUser> _userManager;
+
+		public ReactionService(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
+		{
+			_context = context;
+			_userManager = userManager;
+		}
+		public async Task<Result<CreateReactionResponse>> CreateReactionAsync(string userId, CreateReactionRequest request, CancellationToken cancellationToken = default)
+		{
+			var user = await _userManager.FindByIdAsync(userId);
+			if (user is null)
+				return Result.Failure<CreateReactionResponse>(ReactionErrors.UserNotFound);
+
+			if (!await _context.posts.AnyAsync(p => p.Id == request.PostId, cancellationToken))
+				return Result.Failure<CreateReactionResponse>(ReactionErrors.PostNotFound);
+
+			if (request.CommentId.HasValue)
+			{
+				var comment = await _context.comments.FirstOrDefaultAsync(c => c.Id == request.CommentId.Value, cancellationToken);
+				if (comment is null)
+					return Result.Failure<CreateReactionResponse>(ReactionErrors.CommentNotFound);
+				if (comment.PostId != request.PostId)
+					return Result.Failure<CreateReactionResponse>(ReactionErrors.CommentNotInPost);
+			}
+			var existingReaction = await _context.reactions.FirstOrDefaultAsync(r => r.UserId == userId && r.PostId == request.PostId && r.CommentId == request.CommentId,cancellationToken);
+			Core.Entities.Reaction reaction;
+			if (existingReaction != null)
+			{
+				reaction = existingReaction;
+				_context.reactions.Remove(reaction);
+			}
+			else
+			{
+				reaction = new Core.Entities.Reaction
+				{
+					UserId = userId,
+					PostId = request.PostId,
+					CommentId = request.CommentId,
+					IsReaction = true,
+					Time = DateTime.UtcNow
+				};
+				_context.reactions.Add(reaction);
+			}
+			await _context.SaveChangesAsync(cancellationToken);
+			var response = new CreateReactionResponse(
+				ReactionId: reaction.Id,
+				UserId: userId,
+				UserName: user.UserName!,
+				PostId: reaction.PostId,
+				CommentId: reaction.CommentId,
+				Time: reaction.Time
+			);
+			return Result.Success(response);
+		}
+	}
+}

--- a/InstagramProject.Service/Services/Home/HomeService.cs
+++ b/InstagramProject.Service/Services/Home/HomeService.cs
@@ -39,7 +39,9 @@ namespace InstagramProject.Service.Services.Home
 				.Select(p => new FeedResponse(
 					p.Id,
 					p.UserId,
-					p.User.UserName ?? string.Empty,
+					p.User.UserName,
+					p.User.ProfilePic,
+					p.Content,
 					p.Time,
 					string.IsNullOrEmpty(p.PostMedia)
 						? Enumerable.Empty<string>()
@@ -64,7 +66,7 @@ namespace InstagramProject.Service.Services.Home
 					u.Id,
 					u.UserName!,
 					u.FullName,
-					u.ProfilePic ?? "https://res.cloudinary.com/dbpstijmp/image/upload/v1751892675/awgq5wbmds1147xvxnld.png"
+					u.ProfilePic
 				))
 				.AsNoTracking()
 				.ToListAsync(cancellationToken);
@@ -98,7 +100,7 @@ namespace InstagramProject.Service.Services.Home
 			var suggestions = suggestedUsers
 				.Join(userDetails, su => su.UserId, ud => ud.Id, (su, ud) => new SuggestionsFollowerResponse(
 					ud.UserName!,
-					ud.ProfilePic ?? "https://res.cloudinary.com/dbpstijmp/image/upload/v1751892675/awgq5wbmds1147xvxnld.png",
+					ud.ProfilePic,
 					su.MutualFriendsCount
 				)).ToList();
 


### PR DESCRIPTION
This pull request introduces a new feature for handling reactions (likes/dislikes) on posts and comments, along with some enhancements to the user feed and profile handling. The most important changes include the addition of a `ReactionController` and related service, contracts, and error handling, as well as updates to the feed and user-related responses to include richer details.

### New Reaction Feature:

* **`InstagramProject.Api/Controllers/ReactionController.cs`**: Added a new `ReactionController` to handle creating reactions via the `CreateReact` endpoint. It uses the `IReactionService` to process requests.
* **`InstagramProject.Core/ServiceContract/IReactionService.cs`**: Introduced the `IReactionService` interface with a `CreateReactionAsync` method for managing reactions.
* **`InstagramProject.Service/Reaction/ReactionService.cs`**: Implemented the `ReactionService` to handle reaction creation, including validation for user, post, and comment existence, and toggling reactions.
* **`InstagramProject.Core/Contracts/Reaction/CreateReactionRequest.cs` & `CreateReactionResponse.cs`**: Added request and response models for creating reactions, supporting both posts and comments.
* **`InstagramProject.Core/Errors/Reaction/ReactionErrors.cs`**: Defined custom errors for invalid reaction scenarios, such as user not found, post not found, or comment not belonging to the specified post.

### Dependency Injection Updates:

* **`InstagramProject.Service/DependencyInjection.cs`**: Registered the `ReactionService` with the dependency injection container to enable its use in the application.